### PR TITLE
Revert loud intros through context menu

### DIFF
--- a/src/contextmenu/induct.js
+++ b/src/contextmenu/induct.js
@@ -11,14 +11,15 @@ module.exports = {
     .setDefaultMemberPermissions(0x10000000)
     .setName("Induct User")
     .setType(ApplicationCommandType.User),
+  silent: true,
   async execute(interaction) {
     let dt = new Date().toUTCString();
     await interaction.deferReply({ ephemeral: true });
     await wait(1000);
 
-    let user = interaction.targetMember;
     await interaction.guild.members.fetch();
     await interaction.guild.channels.fetch();
+    let user = await interaction.guild.members.fetch(interaction.targetId);
 
     let general, roles, role;
 
@@ -46,7 +47,7 @@ module.exports = {
 
     if (user.roles.cache.find((r) => r.name === "Guest")) {
       console.log(
-        `${dt} - Warning: ${interaction.user.tag} tried to induct ${user.tag} but they were already inducted.`
+        `${dt} - Warning: ${interaction.user.tag} tried to induct ${user.user.tag} but they were already inducted.`
       );
       return await interaction.editReply({
         content: "User is already inducted.",
@@ -57,9 +58,12 @@ module.exports = {
     await user.roles.add(role);
     await interaction.guild.members.fetch();
 
-    if (general.send(message)) {
+    if (
+      (!this.silent && general.send(message)) ||
+      (this.silent && user.roles.cache.find((r) => r.name === "Guest"))
+    ) {
       console.log(
-        `${dt} - Warning: ${interaction.user.tag} has inducted ${user.tag} into CSS.`
+        `${dt} - Warning: ${interaction.user.tag} has inducted ${user.user.tag} into CSS.`
       );
       await interaction.editReply({
         content: "User inducted successfully.",
@@ -67,7 +71,7 @@ module.exports = {
       });
     } else {
       console.log(
-        `${dt} - Warning: An error occured during ${interaction.user.tag}'s induction of ${user.tag}`
+        `${dt} - Warning: An error occured during ${interaction.user.tag}'s induction of ${user.user.tag}`
       );
       await interaction.editReply({
         content: "Something has gone wrong.",

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -31,8 +31,6 @@ for (const file of contextMenuFiles) {
 
 const rest = new REST({ version: "10" }).setToken(process.env.DISCORD_TOKEN);
 
-console.log(commands);
-
 rest
   .put(Routes.applicationCommands(process.env.CLIENTID), { body: commands })
   .then(() => console.log("Successfully registered application commands."))

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,4 @@ for (const file of eventFiles) {
   }
 }
 
-console.log(client.commands);
-
 client.login();


### PR DESCRIPTION
Prevents the Application menu command from sending a message in general as it has become too spammy. It automatically assumes silent, but can be toggled bag on if desired later on. Also removes unnecessary logging. Stopgap solution until #23  is implemented.