### PR TITLE
Fix makeMember problems with pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TeX-Bot",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index.js",
   "repository": "https://github.com/CSSUoB/TeX-Bot-JS.git",
   "license": "Apache-2.0",
@@ -11,6 +11,7 @@
     "cheerio": "^1.0.0-rc.12",
     "discord.js": "^14.1.2",
     "dotenv": "^16.0.1",
+    "lodash": "^4.17.21",
     "tough-cookie": "^4.0.0"
   },
   "devDependencies": {

--- a/src/commands/makeMember.js
+++ b/src/commands/makeMember.js
@@ -4,6 +4,7 @@ const cheerio = require("cheerio");
 const tough = require("tough-cookie");
 const fs = require("fs");
 const crypto = require("crypto");
+const _ = require("lodash");
 require("../../config/config.js");
 
 const cookie = new tough.Cookie({
@@ -106,13 +107,25 @@ module.exports = {
       return;
     }
 
-    const memberArray = [];
+    const standardMembership = [];
+    const allMembers = [];
+    let memberArray = [];
 
     const $ = cheerio.load(result.data);
-    $("#ctl00_Main_gvMembers > tbody > tr > td:nth-child(2)").each(
-      (index, element) => {
-        memberArray[index] = $(element).text();
-      }
+    $(
+      "#ctl00_Main_rptGroups_ctl03_gvMemberships > tbody:nth-child(1) > tr > td:nth-child(2)"
+    ).each((index, element) => {
+      allMembers[index] = $(element).text();
+    });
+
+    $(
+      "#ctl00_Main_rptGroups_ctl05_gvMemberships > tbody:nth-child(1) > tr > td:nth-child(2)"
+    ).each((index, element) => {
+      standardMembership[index] = $(element).text();
+    });
+
+    memberArray = _.union(standardMembership, allMembers).filter(
+      (element) => element != ""
     );
 
     return memberArray;

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,11 @@ lodash.uniqwith@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz#7a0cbf65f43b5928625a9d4d0dc54b18cadc7ef3"
   integrity sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"


### PR DESCRIPTION
/makemember had issues with the pagination on the guild site; so the functionality from the Python version of TeX has been ported over (primarily concatenating the two All Members and Standard Membership tables). Also takes care of external member's having no ID and creating a problem. Requires the .env file to be updated.